### PR TITLE
Fix README installation path

### DIFF
--- a/haunted-escape-rpg/README.md
+++ b/haunted-escape-rpg/README.md
@@ -15,7 +15,7 @@ Haunted Escape RPG is an 8-bit role-playing game where players take on the roles
    ```
 2. Navigate to the project directory:
    ```
-   cd haunted-escape-rpg
+   cd haunted-escape-rpg/haunted-escape-rpg
    ```
 3. Install the dependencies:
    ```
@@ -36,9 +36,3 @@ Players will explore the haunted house, interact with various objects, and face 
 ## License
 This project is licensed under the MIT License. Feel free to modify and distribute as you wish!
 
-export default class GameState {
-    // Puedes agregar aquí las propiedades del estado del juego
-    constructor() {
-        // Inicializa el estado
-    }
-}


### PR DESCRIPTION
## Summary
- clarify that the `package.json` lives inside the inner folder
- remove stray TypeScript snippet from README

## Testing
- `npm run build`
- `npm start`


------
https://chatgpt.com/codex/tasks/task_e_68593e46c384832089e2100903ae8532