### PR TITLE
Fix GameState storage checks and update interfaces

### DIFF
--- a/haunted-escape-rpg/dist/game/state.js
+++ b/haunted-escape-rpg/dist/game/state.js
@@ -19,15 +19,19 @@ var GameState = /** @class */ (function () {
         // Placeholder for future state updates
     };
     GameState.prototype.save = function () {
-        localStorage.setItem('gameState', JSON.stringify(this));
+        if (typeof localStorage !== 'undefined') {
+            localStorage.setItem('gameState', JSON.stringify(this));
+        }
     };
     GameState.prototype.load = function () {
-        var savedState = localStorage.getItem('gameState');
-        if (savedState) {
-            var state = JSON.parse(savedState);
-            this.currentScene = state.currentScene;
-            this.playerPositions = state.playerPositions;
-            this.inventory = state.inventory;
+        if (typeof localStorage !== 'undefined') {
+            var savedState = localStorage.getItem('gameState');
+            if (savedState) {
+                var state = JSON.parse(savedState);
+                this.currentScene = state.currentScene;
+                this.playerPositions = state.playerPositions;
+                this.inventory = state.inventory;
+            }
         }
     };
     GameState.prototype.reset = function () {

--- a/haunted-escape-rpg/src/game/state.ts
+++ b/haunted-escape-rpg/src/game/state.ts
@@ -22,16 +22,20 @@ export class GameState {
     }
 
     save() {
-        localStorage.setItem('gameState', JSON.stringify(this));
+        if (typeof localStorage !== 'undefined') {
+            localStorage.setItem('gameState', JSON.stringify(this));
+        }
     }
 
     load() {
-        const savedState = localStorage.getItem('gameState');
-        if (savedState) {
-            const state = JSON.parse(savedState);
-            this.currentScene = state.currentScene;
-            this.playerPositions = state.playerPositions;
-            this.inventory = state.inventory;
+        if (typeof localStorage !== 'undefined') {
+            const savedState = localStorage.getItem('gameState');
+            if (savedState) {
+                const state = JSON.parse(savedState);
+                this.currentScene = state.currentScene;
+                this.playerPositions = state.playerPositions;
+                this.inventory = state.inventory;
+            }
         }
     }
 

--- a/haunted-escape-rpg/src/types/index.ts
+++ b/haunted-escape-rpg/src/types/index.ts
@@ -9,15 +9,17 @@ export interface Character {
 
 export interface Scene {
     description: string;
+    describeEnvironment(): void;
     interact(): void;
     events: string[];
 }
 
 export interface GameState {
-    playerPosition: string;
-    inventory: string[];
+    playerPositions: { [key: string]: { x: number; y: number } };
+    inventory: { [key: string]: any };
     currentScene: string;
     save(): void;
     load(): void;
     reset(): void;
 }
+


### PR DESCRIPTION
## Summary
- ensure GameState won't fail if `localStorage` is absent
- clarify GameState interface and Scene interface
- rebuild dist files

## Testing
- `npm run build`
- `npm start`


------
https://chatgpt.com/codex/tasks/task_e_68594071d5b88320b29d98be4e4d0234